### PR TITLE
Fix bug with missing points in Python 3

### DIFF
--- a/svg/charts/graph.py
+++ b/svg/charts/graph.py
@@ -23,12 +23,6 @@ except ImportError:
 # cause the SVG profile to be loaded
 __import__('svg.charts.css')
 
-def sort_multiple(arrays):
-	"sort multiple lists (of equal size) using the first list for the sort keys"
-	tuples = zip(*arrays)
-	tuples.sort()
-	return zip(*tuples)
-
 class Graph(object):
 	"""
 	Base object for generating SVG Graphs
@@ -356,7 +350,7 @@ class Graph(object):
 			labels = enumerate(iter(labels))
 			start = int(not self.step_include_first_x_label)
 			labels = islice(labels, start, None, self.step_x_labels)
-			map(self.draw_x_label, labels)
+			list(map(self.draw_x_label, labels))
 			self.draw_x_guidelines(self.field_width(), count)
 
 	def draw_x_label(self, label):
@@ -416,7 +410,7 @@ class Graph(object):
 		labels = enumerate(iter(labels))
 		start = int(not self.step_include_first_y_label)
 		labels = islice(labels, start, None, self.step_y_labels)
-		map(self.draw_y_label, labels)
+		list(map(self.draw_y_label, labels))
 		self.draw_y_guidelines(self.field_height(), count)
 
 	def get_y_offset(self):
@@ -652,7 +646,7 @@ class Graph(object):
 			' Based on Perl SVG:TT:Graph by Leo Lapworth & Stephan Morgan ',
 			' '+'/'*66,
 			)
-		map(self.root.append, map(etree.Comment, comment_strings))
+		list(map(self.root.append, map(etree.Comment, comment_strings)))
 
 		defs = etree.SubElement(self.root, 'defs')
 		self.add_defs(defs)
@@ -694,7 +688,7 @@ class Graph(object):
 		class_vars = class_dict(self)
 		loader = functools.partial(self.load_resource_stylesheet,
 			subs=class_vars)
-		sheets = map(loader, self.stylesheet_names)
+		sheets = list(map(loader, self.stylesheet_names))
 		return sheets
 
 	def get_stylesheet(self):

--- a/svg/charts/plot.py
+++ b/svg/charts/plot.py
@@ -7,6 +7,7 @@ from itertools import count, chain
 
 import six
 from lxml import etree
+from six.moves import zip
 
 from svg.charts.graph import Graph
 
@@ -250,7 +251,7 @@ class Plot(Graph):
 				(data['data'][self.x_data_index][0],
 				data['data'][self.y_data_index][0])
 			)
-			data_points = zip(*data['data'])
+			data_points = list(zip(*data['data']))
 			graph_points = self.get_graph_points(data_points)
 			lpath = self.get_lpath(graph_points)
 			if self.area_fill:
@@ -277,7 +278,7 @@ class Plot(Graph):
 
 	def _draw_constant_lines(self):
 		if hasattr(self, 'constant_lines'):
-			map(self.__draw_constant_line, self.constant_lines)
+			list(map(self.__draw_constant_line, self.constant_lines))
 
 	def __draw_constant_line(self, value_label_style):
 		"Draw a constant line on the y-axis with the label"
@@ -307,7 +308,7 @@ class Plot(Graph):
 		del self.__transform_parameters['self']
 
 	def get_graph_points(self, data_points):
-		return map(self.transform_output_coordinates, data_points)
+		return list(map(self.transform_output_coordinates, data_points))
 
 	def get_lpath(self, points):
 		points = map(lambda p: "%f %f" % p, points)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -19,3 +19,12 @@ class TestPlot:
 		g = Plot(dict(css_inline=True))
 		g.add_data(dict(data=[1, 0, 2, 1], title='foo'))
 		g.burn()
+
+	def test_python3_show_points(self):
+		"""
+		Test that show_data_points creates
+		circle elements in output.
+		"""
+		g = Plot(dict(show_data_points=True))
+		g.add_data(dict(data=[1, 0, 2, 1], title='foo'))
+		assert b'circle' in g.burn()


### PR DESCRIPTION
Creating plots in Python has buggy output with missing elements (because `zip` and `map` create generators in Python3).

Here's an example that's supposed to have data points and axes:

![missingpoints](https://cloud.githubusercontent.com/assets/1215412/17246832/8f938fc0-5586-11e6-97fd-a07e5ab6c292.png)

I added a test, #28cbaa9; the next commit fixes it by adding a lot of `list()` calls.

