### PR TITLE
labelled datapoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,36 @@
+X.Y.Z
+=====
+
+* ``svg.charts.plot.Plot``
+  (and hence its subclass ``svg.charts.time_series.Plot``)
+  now accept data as a sequence of pairs.  Example::
+
+      import svg.charts.plot
+
+      g = svg.charts.plot.Plot()
+      g.add_data(dict(title='Example',
+                      data=[(1, 1), (2, 4), (3, 9)]))
+
+* data point labels that are drawn when
+  ``show_data_values = True`` can have their label changed
+  from the default (which is the y-value) by giving a data item
+  a ``.text`` attribute.
+  It is convenient to used ``namedtuple()`` for this::
+
+      import svg.charts.plot
+      from collections import namedtuple
+
+      Datum = nametuple("Datum", 'x y text')
+
+      g = svg.charts.plot.Plot()
+      g.add_data(dict(title='Example',
+                      data=[Datum(1, 1, 'first'),
+                            Datum(2, 4, 'second'),
+                            Datum(3, 9, 'third')]))
+
+  (in fact data items can have any extra attribute;
+  only ``.text`` is used currently)
+
 3.3.1
 =====
 

--- a/svg/charts/plot.py
+++ b/svg/charts/plot.py
@@ -145,15 +145,38 @@ class Plot(Graph):
 		self._scale_x_divisions = val
 
 	def validate_data(self, data):
-		# Should be pairs.
-		for (i, p) in enumerate(data['data']):
+		series = data['data']
+		try:
+		    [len(x) for x in series]
+		except TypeError:
+		    self.validate_data_flat(series)
+		else:
+		    self.validate_data_pairs(series)
+
+	def validate_data_flat(self, series):
+		# Should be [ x, y, ... ] pairs.
+		if len(series) % 2 != 0:
+			tmpl = "Expecting x,y pairs for data points for %s."
+			msg = tmpl % self.__class__.__name__
+			raise ValueError(msg)
+		
+
+	def validate_data_pairs(self, series):
+		# Should be pairs (or wider tuples).
+		for (i, p) in enumerate(series):
 			if len(p) < 2:
 				tmpl = "Expecting (x,y) pairs for data points for %s."
 				msg = tmpl % self.__class__.__name__
 				raise ValueError(msg)
 
 	def process_data(self, data):
-		data['data'] = sorted(data['data'])
+		series = data['data']
+		try:
+			[len(x) for x in series]
+		except TypeError:
+			series = list(get_pairs(series))
+		data['data'] = sorted(series)
+
 
 	def calculate_left_margin(self):
 		super(Plot, self).calculate_left_margin()

--- a/svg/charts/plot.py
+++ b/svg/charts/plot.py
@@ -147,7 +147,7 @@ class Plot(Graph):
 	def validate_data(self, data):
 		# Should be pairs.
 		for (i, p) in enumerate(data['data']):
-			if len(p) != 2:
+			if len(p) < 2:
 				tmpl = "Expecting (x,y) pairs for data points for %s."
 				msg = tmpl % self.__class__.__name__
 				raise ValueError(msg)
@@ -180,7 +180,7 @@ class Plot(Graph):
 		  self.get_single_axis_values(axis, ds) for ds in self.data]))
 		spec_max = getattr(self, 'max_%s_value' % axis)
 		if spec_max is not None:
-                          max_value = max(max_value, spec_max)
+			  max_value = max(max_value, spec_max)
 		return max_value
 
 	def data_min(self, axis):
@@ -316,7 +316,7 @@ class Plot(Graph):
 		return 'L' + ' '.join(points)
 
 	def transform_output_coordinates(self, point):
-		x, y = point
+		x, y = point[:2]
 		x_min = self.__transform_parameters['x_min']
 		x_step = self.__transform_parameters['x_step']
 		y_min = self.__transform_parameters['y_min']
@@ -330,7 +330,9 @@ class Plot(Graph):
 	def draw_data_points(self, line, data_points, graph_points):
 		if not self.show_data_points \
 			and not self.show_data_values: return
-		for ((dx,dy),(gx,gy)) in six.moves.zip(data_points, graph_points):
+		for (dp,(gx,gy)) in six.moves.zip(data_points, graph_points):
+			dx = dp[0]
+			dy = dp[1]
 			if self.show_data_points:
 				doc = {
 					'cx': str(gx),
@@ -341,7 +343,8 @@ class Plot(Graph):
 				etree.SubElement(self.graph, 'circle', doc)
 			if self.show_data_values:
 				self.add_popup(gx, gy, self.format(dx, dy))
-			self.make_datapoint_text(gx, gy-6, dy)
+			text = getattr(dp, 'text', dy)
+			self.make_datapoint_text(gx, gy-6, text)
 
 	def format(self, x, y):
 		return '(%0.2f, %0.2f)' % (x,y)

--- a/svg/charts/plot.py
+++ b/svg/charts/plot.py
@@ -145,15 +145,15 @@ class Plot(Graph):
 		self._scale_x_divisions = val
 
 	def validate_data(self, data):
-		if len(data['data']) % 2 != 0:
-			tmpl = "Expecting x,y pairs for data points for %s."
-			msg = tmpl % self.__class__.__name__
-			raise ValueError(msg)
+		# Should be pairs.
+		for (i, p) in enumerate(data['data']):
+			if len(p) != 2:
+				tmpl = "Expecting (x,y) pairs for data points for %s."
+				msg = tmpl % self.__class__.__name__
+				raise ValueError(msg)
 
 	def process_data(self, data):
-		pairs = list(get_pairs(data['data']))
-		pairs.sort()
-		data['data'] = list(zip(*pairs))
+		data['data'] = sorted(data['data'])
 
 	def calculate_left_margin(self):
 		super(Plot, self).calculate_left_margin()
@@ -167,22 +167,25 @@ class Plot(Graph):
 		label_right = len(right_label_text) / 2 * self.font_size * 0.6
 		self.border_right = max(label_right, self.border_right)
 
-	def data_max(self, axis):
+	def get_single_axis_values(self, axis, dataset):
+		"""
+		Return all the values for a single axis of the data.
+		"""
 		data_index = getattr(self, '%s_data_index' % axis)
-		get_value = lambda set: set['data'][data_index]
-		max_value = max(chain(*map(get_value, self.data)))
-		# above is same as
-		#max_value = max(map(lambda set: max(set['data'][data_index]), self.data))
+		return [p[data_index] for p in dataset['data']]
+
+
+	def data_max(self, axis):
+		max_value = max(chain(*[
+		  self.get_single_axis_values(axis, ds) for ds in self.data]))
 		spec_max = getattr(self, 'max_%s_value' % axis)
-		# Python 3 doesn't allow comparing None to int, so use -8
-		if spec_max is None: spec_max = float('-Inf')
-		max_value = max(max_value, spec_max)
+		if spec_max is not None:
+                          max_value = max(max_value, spec_max)
 		return max_value
 
 	def data_min(self, axis):
-		data_index = getattr(self, '%s_data_index' % axis)
-		get_value = lambda set: set['data'][data_index]
-		min_value = min(chain(*map(get_value, self.data)))
+		min_value = min(chain(*[
+		  self.get_single_axis_values(axis, ds) for ds in self.data]))
 		spec_min = getattr(self, 'min_%s_value' % axis)
 		if spec_min is not None:
 			min_value = min(min_value, spec_min)
@@ -246,10 +249,10 @@ class Plot(Graph):
 		self.load_transform_parameters()
 		for line, data in six.moves.zip(count(1), self.data):
 			x_start, y_start = self.transform_output_coordinates(
-				(data['data'][self.x_data_index][0],
-				data['data'][self.y_data_index][0])
+				(data['data'][0][self.x_data_index],
+				data['data'][0][self.y_data_index])
 			)
-			data_points = list(zip(*data['data']))
+			data_points = data['data']
 			graph_points = self.get_graph_points(data_points)
 			lpath = self.get_lpath(graph_points)
 			if self.area_fill:

--- a/svg/charts/time_series.py
+++ b/svg/charts/time_series.py
@@ -141,8 +141,11 @@ class Plot(svg.charts.plot.Plot):
 
 	def process_data(self, data):
 		super(Plot, self).process_data(data)
-		# the date should be in the first element, so parse it out
-		data['data'][0] = list(map(self.parse_date, data['data'][0]))
+		# the date should be in the first axis;
+		# replace value with parsed date.
+		series = data['data']
+		data['data'] = [(self.parse_date(p[0]),) + tuple(p[1:])
+				for p in series]
 
 	_min_x_value = svg.charts.plot.Plot.min_x_value
 	def get_min_x_value(self):

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -21,9 +21,34 @@ def sample_Plot():
 		'stagger_y_labels': True,
 		'show_x_guidelines': True
 	})
-	g.add_data({'data': [1, 25, 2, 30, 3, 45], 'title': 'series 1'})
-	g.add_data({'data': [1,30, 2, 31, 3, 40], 'title': 'series 2'})
-	g.add_data({'data': [.5,35, 1, 20, 3, 10.5], 'title': 'series 3'})
+	g.add_data({'data': [[1, 25], [2, 30], [3, 45]],
+		    'title': 'series 1'})
+	g.add_data({'data': [[1, 30], [2, 31], [3, 40]],
+		    'title': 'series 2'})
+	g.add_data({'data': [[.5, 35], [1, 20], [3, 10.5]],
+		    'title': 'series 3'})
+	return g
+
+def sample_PlotTextLabels():
+	g = Plot({
+		'draw_lines_between_points': False,
+		'min_x_value': 0,
+		'min_y_value': 0,
+		'show_x_guidelines': True
+	})
+	# Processed Apple production 2015
+	# Any object with a .text attribute will do;
+	# we like namedtuple().
+
+	from collections import namedtuple
+
+	Datum = namedtuple("Datum", "x y text")
+
+	g.add_data({'data': [Datum(8.24, 80.85, 'ES'),
+			     Datum(0.17, 6.73, 'IE'),
+			     Datum(0, 0, 'IS'),
+			    ],
+		    'title': 'Processed Apple'})
 	return g
 
 def sample_TimeSeries():
@@ -40,6 +65,7 @@ def sample_TimeSeries():
 
 def generate_samples():
 	yield 'Plot', sample_Plot()
+	yield 'PlotTextLabels', sample_PlotTextLabels()
 	yield 'TimeSeries', sample_TimeSeries()
 	yield 'VerticalBar', SampleBar.vertical()
 	yield 'HorizontalBar', SampleBar.horizontal()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -28,3 +28,31 @@ class TestPlot:
 		g = Plot(dict(show_data_points=True))
 		g.add_data(dict(data=[1, 0, 2, 1], title='foo'))
 		assert b'circle' in g.burn()
+
+	def test_pairs(self):
+		"""
+		Test that it is acceptable to use pairs for data.
+		"""
+		g = Plot(dict(show_data_points=True))
+		g.add_data(dict(data=[(1, 0), (2, 1)], title='pairs'))
+		assert b'circle' in g.burn()
+
+	def test_text(self):
+		"""
+		Test that data with .text attributes make
+		text labels.
+		"""
+		from collections import namedtuple
+
+		D = namedtuple("D", 'x y text')
+
+		g = Plot(dict(show_data_values=True))
+		g.add_data(dict(data=[
+			D(1, 0, 'Sam'),
+			D(2, 1, 'Dan'),
+			],
+			title='labels'))
+		svg = g.burn()
+		assert b'Sam' in svg
+		assert b'Dan' in svg
+

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -12,6 +12,8 @@ def test_field_width():
 	g.stagger_x_labels = True
 	g.x_label_format = '%d-%b %H:%M'
 
-	g.add_data({'data': ['2005-12-21T00:00:00', 20, '2005-12-22T00:00:00', 21], 'title': 'series 1'})
+	g.add_data({'data': [('2005-12-21T00:00:00', 20),
+			     ('2005-12-22T00:00:00', 21)],
+		    'title': 'series 1'})
 	g.burn()
 	assert g.field_width() > 1


### PR DESCRIPTION
I wanted datapoints to have text labels that were something other than their y-value.

I think this PR is a bit controversial than usual so it's offered more in the spirit of a discussion.

I have a proposal that produces plots looking like this:

![wheat-svg](https://cloud.githubusercontent.com/assets/1215412/17651660/a16da0e8-6263-11e6-915d-79c0c0999724.png)

There are several things going on in this PR in order to achieve the above.

1) a series of data points is now represented as a list of pairs. By "pair" I mean any object for which `[0]` and `[1]` both work. There may be values at other indexes and attributes. After `process_data`, each data series in `self.data` is a `dict` (as before) that has a `'data'` key (as before) that is a sequence of pairs. This last bit is different.
2) in `draw_data_points` if a datum has a `.text` attribute then that is used for the text label; otherwise the y value is used, as before.
3) various rearrangements to the order in which axes are indexed.
4) in order to support the previous representation of data for `add_data` it is also acceptable to add data as a single sequence of alternating `x` and `y`. `process_data` will convert it into a sequence of 2-tuples. The rule used is that if each item of the sequence has a valid `len()` call then it is assumed to be a sequence of pairs and used as-is; otherwise it is converted into a sequence of pairs.
5) `time_series` is modified slightly because the timestamp is now the 0th element of each pair.
6) (mostly incidental) `data_min` and `data_max` have been somewhat unified. I loved `float('Inf')` (see https://pypi.python.org/pypi/inf), but it's not so clear, and the code tests with `is None` anyway.

An example of how to use this is here: https://github.com/drj11/eurostat/blob/b4641c8018fa459dade224d8f3ee640f02e2e508/chart.py#L70-L72 (this is the code that produced the above plot). Note how `Datum` is a `namedtuple` that has a `.text` attribute at index 2.

Note that `draw_data` used a `list(zip(*))` to convert the data to a list of pairs immediately before processing; this step is now not needed.

Handling the data as a sequence of objects allows all sorts of potential customisation. For example, the radius of the circle used to plot the point could be `getattr(dp, 'r', '2.5')`. That's for the future though.