### PR TITLE
Drop support for Python 3.4 and earlier, including 2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: python
 
 python:
-- 2.7
+- 3.5
 - 3.6
 - &latest_py3 3.7
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+6.0
+===
+
+* #26: Drop support for Python 3.4 and earlier (including 2.7).
+
 5.0
 ===
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,12 @@ classifiers =
 	Intended Audience :: Developers
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: MIT License
-	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
 
 [options]
 packages = find:
 include_package_data = true
-python_requires = >=2.7
+python_requires = >=3.5
 install_requires =
 	cssutils>=0.9.8a3
 	python-dateutil>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ install_requires =
 	python-dateutil>=2.0
 	lxml>=2.0
 	more_itertools
-	six
 	tempora>=1.3
 	jaraco.itertools
 setup_requires = setuptools_scm >= 1.15.0

--- a/svg/charts/bar.py
+++ b/svg/charts/bar.py
@@ -4,8 +4,6 @@ from __future__ import division
 
 from itertools import chain
 
-from six.moves import map
-
 from lxml import etree
 from svg.charts.graph import Graph
 

--- a/svg/charts/graph.py
+++ b/svg/charts/graph.py
@@ -25,7 +25,7 @@ from lxml import etree
 __import__('svg.charts.css')
 
 
-class Graph(object):
+class Graph:
 	"""
 	Base object for generating SVG Graphs
 
@@ -718,7 +718,7 @@ class Graph(object):
 		return functools.reduce(merge_sheets, self.get_stylesheet_resources())
 
 
-class DrawHooks(object):
+class DrawHooks:
 	"""
 	Mix-in for Graph subclasses providing hooks at
 	various points in the rendering of a Graph.
@@ -741,7 +741,7 @@ class DrawHooks(object):
 		pass
 
 
-class class_dict(object):
+class class_dict:
 	"Emulates a dictionary, but retrieves class attributes"
 	def __init__(self, obj):
 		self.__obj__ = obj

--- a/svg/charts/graph.py
+++ b/svg/charts/graph.py
@@ -16,8 +16,6 @@ except Exception:
 	import collections
 	collections.abc = collections
 
-from six.moves import map
-
 import pkg_resources
 import cssutils
 from lxml import etree

--- a/svg/charts/line.py
+++ b/svg/charts/line.py
@@ -4,8 +4,6 @@ import itertools
 import functools
 from operator import itemgetter, add
 
-from six.moves import map
-
 from lxml import etree
 from more_itertools.recipes import flatten
 

--- a/svg/charts/pie.py
+++ b/svg/charts/pie.py
@@ -1,9 +1,6 @@
 import math
 import itertools
 
-import six
-from six.moves import map, zip
-
 from lxml import etree
 
 from svg.charts.graph import Graph
@@ -116,7 +113,7 @@ class Pie(Graph):
 
 		>>> graph.add_data({data:[6,9,3,4]}) # doctest: +SKIP
 		"""
-		pairs = six.moves.zip_longest(self.data, data_descriptor['data'])
+		pairs = itertools.zip_longest(self.data, data_descriptor['data'])
 		self.data = list(itertools.starmap(robust_add, pairs))
 
 	def add_defs(self, defs):

--- a/svg/charts/plot.py
+++ b/svg/charts/plot.py
@@ -5,9 +5,6 @@
 import functools
 from itertools import count, chain
 
-import six
-from six.moves import map
-
 from lxml import etree
 import more_itertools
 
@@ -288,7 +285,7 @@ class Plot(Graph):
 
 	def draw_data(self):
 		self.load_transform_parameters()
-		for line, data in six.moves.zip(count(1), self.data):
+		for line, data in zip(count(1), self.data):
 			x_start, y_start = self.transform_output_coordinates((
 				data['data'][0][self.x_data_index],
 				data['data'][0][self.y_data_index],
@@ -373,7 +370,7 @@ class Plot(Graph):
 		if not self.show_data_points \
 			and not self.show_data_values:
 				return
-		for (dp, (gx, gy)) in six.moves.zip(data_points, graph_points):
+		for (dp, (gx, gy)) in zip(data_points, graph_points):
 			dx = dp[0]
 			dy = dp[1]
 			if self.show_data_points:

--- a/svg/charts/schedule.py
+++ b/svg/charts/schedule.py
@@ -14,7 +14,7 @@ from .util import reverse_mapping, flatten_mapping
 __all__ = 'Schedule',
 
 
-class TimeScale(object):
+class TimeScale:
 	"Describes a scale factor based on time instead of a scalar"
 	def __init__(self, width, range):
 		self.width = width

--- a/svg/charts/schedule.py
+++ b/svg/charts/schedule.py
@@ -2,12 +2,9 @@ from __future__ import absolute_import
 
 import re
 
-from six.moves import map, zip
-
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from lxml import etree
-import six
 from more_itertools.recipes import grouper
 from tempora import divide_timedelta_float, date_range, divide_timedelta
 
@@ -190,7 +187,7 @@ class Schedule(Graph):
 		return parse(date_string)
 
 	def set_min_x_value(self, value):
-		if isinstance(value, six.string_types):
+		if isinstance(value, str):
 			value = self.parse_date(value)
 		self._min_x_value = value
 

--- a/svg/charts/time_series.py
+++ b/svg/charts/time_series.py
@@ -2,8 +2,6 @@ import re
 from time import mktime
 import datetime
 
-from six.moves import map
-
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 

--- a/svg/charts/util.py
+++ b/svg/charts/util.py
@@ -1,7 +1,5 @@
 from __future__ import division
 
-from six.moves import zip
-
 from jaraco.itertools import always_iterable
 
 


### PR DESCRIPTION
It's time to stop supporting Python 2.7 and this PR introduces that change. Thanks to the `python_requires` designation, this change should not require any action for projects using recent pip versions to install... they will continue to get 5.0. But only those using 6.0 on Python 3.5 and later will get improvements going forward. Bug fixes might be selectively back-ported to 5.0.x releases.