### PR TITLE
Easier custom style and an example for it

### DIFF
--- a/svg/charts/graph.py
+++ b/svg/charts/graph.py
@@ -724,7 +724,13 @@ class Graph:
     def load_resource_stylesheet(name, subs=None):
         if subs is None:
             subs = dict()
-        template = importlib_resources.read_text('svg.charts', name)
+        try:
+            # attempt read from library files
+            template = importlib_resources.read_text('svg.charts', name)
+        except FileNotFoundError:
+            # attempt read from calling code local files
+            with open(name, "r") as f:
+                template = f.read()
         source = template % subs
         return cssutils.parseString(source)
 

--- a/tests/custom_graph.css
+++ b/tests/custom_graph.css
@@ -1,0 +1,91 @@
+/*
+Base styles for svg.charts.Graph
+*/
+
+.svgBackground{
+  fill:#222222;
+}
+.graphBackground{
+  fill:#343434;
+}
+
+/* graphs titles */
+.mainTitle{
+  text-anchor: middle;
+  fill: #454545;
+  font-size: %(title_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+.subTitle{
+  text-anchor: middle;
+  fill: #999999;
+  font-size: %(subtitle_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.axis{
+  stroke: #aaaaaa;
+  stroke-width: 1px;
+}
+
+.guideLines{
+  stroke: #666666;
+  stroke-width: 1px;
+  stroke-dasharray: 5,5;
+}
+
+.xAxisLabels{
+  text-anchor: middle;
+  fill: #aaaaaa;
+  font-size: %(x_label_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.yAxisLabels{
+  text-anchor: end;
+  fill: #aaaaaa;
+  font-size: %(y_label_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.xAxisTitle{
+  text-anchor: middle;
+  fill: #ff0000;
+  font-size: %(x_title_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.yAxisTitle{
+  fill: #ff0000;
+  text-anchor: middle;
+  font-size: %(y_title_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.dataPointLabel{
+  fill: #aaaaaa;
+  text-anchor:middle;
+  font-size: 10px;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}
+
+.staggerGuideLine{
+  fill: none;
+  stroke: #aaaaaa;
+  stroke-width: 0.5px;
+}
+
+.keyText{
+  fill: #aaaaaa;
+  text-anchor:start;
+  font-size: %(key_font_size)dpx;
+  font-family: "Arial", sans-serif;
+  font-weight: normal;
+}

--- a/tests/custom_graph.css
+++ b/tests/custom_graph.css
@@ -1,5 +1,5 @@
 /*
-Base styles for svg.charts.Graph
+Customized styles for svg.charts.Graph
 */
 
 .svgBackground{

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -24,6 +24,22 @@ def sample_Plot():
     return g
 
 
+def sample_custom_style_Plot():
+    g = Plot({
+        'min_x_value': 0,
+        'min_y_value': 0,
+        'area_fill': True,
+        'stagger_x_labels': True,
+        'stagger_y_labels': True,
+        'show_x_guidelines': True,
+        'stylesheet_names': ['custom_graph.css', 'plot.css'],
+    })
+    g.add_data({'data': [[1, 25], [2, 30], [3, 45]], 'title': 'series 1'})
+    g.add_data({'data': [[1, 30], [2, 31], [3, 40]], 'title': 'series 2'})
+    g.add_data({'data': [[0.5, 35], [1, 20], [3, 10.5]], 'title': 'series 3'})
+    return g
+
+
 def sample_PlotTextLabels():
     g = Plot({
         'draw_lines_between_points': False,
@@ -68,6 +84,7 @@ def sample_TimeSeries():
 
 def generate_samples():
     yield 'Plot', sample_Plot()
+    yield 'CustomStylePlot', sample_custom_style_Plot()
     yield 'PlotTextLabels', sample_PlotTextLabels()
     yield 'TimeSeries', sample_TimeSeries()
     yield 'VerticalBar', SampleBar.vertical()


### PR DESCRIPTION
A quick attempt at an easier way to apply custom style sheets as a resolution for #3 

This relies on the existing `stylesheet_names` configuration option and only extends it to allow attempt to find files local to the code running if it fails to find the named stylesheet within the libraries own files. 

With this mechanism you can make your own style  sheet template(s) with whatever values you want and easily apply them by setting the `stylesheet_names` to point to your files.

This was the way that first came to mind for me to try when I was attempting to apply the custom style, I found that it didn't work and when researching what the intended API was I found #3 with the wish for something easier. So I took a shot at implementing the way that I had tried it and it was fairly straight forward.

`tests/samples.py` was updated to include an example usage of this functionality. It now includes a darker styled version of the Plot sample.